### PR TITLE
feat: add optional ruleName for prefixed folders and update UI

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -31,10 +31,13 @@
 
 @media screen and (min-width: 780px) {
     .rapid-notes-settings-entry input[type="text"]:first-child {
-        max-width: 60px;
+        max-width: 60px; /* Prefix */
     }
     .rapid-notes-settings-entry input[type="text"]:nth-child(2) {
-        max-width: 90px;
+        max-width: 90px; /* Real prefix */
+    }
+    .rapid-notes-settings-entry input[type="text"]:nth-child(4) {
+        max-width: 120px; /* Rule Name (after folder search) */
     }
 }
 
@@ -47,7 +50,13 @@
     .rapid-notes-settings-entry input[type="text"]:first-child,
     .rapid-notes-settings-entry input[type="text"]:nth-child(2) {
         flex-grow: 1;
-        flex-basis: 44%;
+        flex-basis: 44%; /* Prefix and Real prefix side by side */
+        width: 100%;
+    }
+    
+    .rapid-notes-settings-entry input[type="text"]:nth-child(4) {
+        flex-grow: 1;
+        flex-basis: 100%; /* Rule Name takes full width on mobile */
         width: 100%;
     }
 }


### PR DESCRIPTION
- Introduce ruleName property to prefixed folder settings for a user- 
  friendly display name in input suggestions.
- Update modal suggestions to show ruleName if available, falling back 
  to folder path.
- Enhance settings UI with a new input for Rule Name and explanatory 
  text.
- Adjust CSS to accommodate the new input field and improve layout on 
  different screen sizes.
- Add tooltip to toggle for better clarity on command registration.

New settings:
<img width="802" height="540" alt="Snipaste_2025-07-29_15-26-16" src="https://github.com/user-attachments/assets/9e752c21-6c90-4e4e-8a58-a0ec4eb2ac2b" />

Display with rule name (if not empty):
<img width="733" height="201" alt="Snipaste_2025-07-29_15-26-31" src="https://github.com/user-attachments/assets/1e514719-7b66-4c68-aad4-2884531788e1" />

